### PR TITLE
Fix VirtualFreeEx size argument

### DIFF
--- a/launcher.cpp.in
+++ b/launcher.cpp.in
@@ -122,7 +122,7 @@ bool Inject_Dll(const char *dllname, HANDLE hProcess)
 
     // Clean up
     CloseHandle(hThread);
-    VirtualFreeEx(hProcess, pLibRemote, sizeof(szLibPath), MEM_RELEASE);
+    VirtualFreeEx(hProcess, pLibRemote, 0, MEM_RELEASE);
 
     // LoadLibrary return is 0 on failure.
     return hLibModule != 0;


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfreeex

> If the dwFreeType parameter is MEM_RELEASE, dwSize must be 0 (zero).